### PR TITLE
fix: properly handle URL inputs with authentication support

### DIFF
--- a/src/services/file-reader.service.ts
+++ b/src/services/file-reader.service.ts
@@ -5,21 +5,40 @@ import type { OpenApiSpecType } from '../types/openapi';
 import { OpenApiSpec } from '../types/openapi';
 
 export class SyncFileReaderService implements OpenApiFileReader {
-  async readFile(path: string): Promise<string> {
-    // Check if path is a URL
+  private isUrl(path: string): boolean {
     try {
       const url = new URL(path);
-      // If it's a valid URL, fetch it
-      const response = await fetch(url.toString());
-      if (!response.ok) {
-        throw new Error(`Failed to fetch ${path}: ${String(response.status)} ${response.statusText}`);
-      }
-
-      return await response.text();
+      return url.protocol === 'http:' || url.protocol === 'https:';
     } catch {
-      // If URL parsing fails, treat it as a local file path
-      return readFileSync(path, 'utf8');
+      return false;
     }
+  }
+
+  async readFile(path: string): Promise<string> {
+    if (this.isUrl(path)) {
+      return await this.fetchUrl(path);
+    }
+
+    return readFileSync(path, 'utf8');
+  }
+
+  private async fetchUrl(path: string): Promise<string> {
+    const url = new URL(path);
+
+    const headers: Record<string, string> = {};
+    if (url.username || url.password) {
+      const credentials = `${decodeURIComponent(url.username)}:${decodeURIComponent(url.password)}`;
+      headers['Authorization'] = `Basic ${btoa(credentials)}`;
+      url.username = '';
+      url.password = '';
+    }
+
+    const response = await fetch(url.toString(), { headers });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${path}: ${String(response.status)} ${response.statusText}`);
+    }
+
+    return await response.text();
   }
 }
 

--- a/tests/integration/cli-comprehensive.test.ts
+++ b/tests/integration/cli-comprehensive.test.ts
@@ -125,5 +125,21 @@ describe('CLI Comprehensive Integration', () => {
       const outputFile = resolve(testOutputDir, 'api.ts');
       expect(existsSync(outputFile)).toBe(true);
     });
+
+    it('should generate code from a remote URL', () => {
+      execSync(`node ./dist/src/cli.js --input https://petstore3.swagger.io/api/v3/openapi.json --output ${testOutputDir}`, {
+        encoding: 'utf-8',
+        cwd,
+        timeout: 30000
+      });
+
+      const outputFile = resolve(testOutputDir, 'api.ts');
+      expect(existsSync(outputFile)).toBe(true);
+
+      const content = readFileSync(outputFile, 'utf-8');
+      expect(content).toContain('export default class');
+      expect(content).toContain('class ResponseValidationError<T> extends Error');
+      expect(content).toContain('import { z }');
+    });
   });
 });

--- a/tests/unit/file-reader.test.ts
+++ b/tests/unit/file-reader.test.ts
@@ -1,8 +1,7 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { OpenApiFileParserService, SyncFileReaderService } from '../../src/services/file-reader.service';
-import { join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { dirname } from 'node:path';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -32,7 +31,6 @@ describe('SyncFileReaderService', () => {
     });
 
     it('should handle URLs', async () => {
-      // Mock fetch for URL test
       const originalFetch = global.fetch;
       global.fetch = vi.fn().mockResolvedValue({
         ok: true,
@@ -41,6 +39,7 @@ describe('SyncFileReaderService', () => {
 
       const content = await reader.readFile('https://example.com/openapi.json');
       expect(content).toBeTruthy();
+      expect(global.fetch).toHaveBeenCalledWith('https://example.com/openapi.json', { headers: {} });
 
       global.fetch = originalFetch;
     });
@@ -54,11 +53,52 @@ describe('SyncFileReaderService', () => {
       } as Response);
       global.fetch = mockFetch;
 
-      await expect(reader.readFile('https://example.com/not-found.json')).rejects.toThrow();
+      await expect(reader.readFile('https://example.com/not-found.json')).rejects.toThrow('Failed to fetch');
 
-      // Verify fetch was called
-      expect(mockFetch).toHaveBeenCalledWith('https://example.com/not-found.json');
       global.fetch = originalFetch;
+    });
+
+    it('should propagate network errors for URLs instead of falling back to readFileSync', async () => {
+      const originalFetch = global.fetch;
+      global.fetch = vi.fn().mockRejectedValue(new TypeError('fetch failed'));
+
+      await expect(reader.readFile('https://example.com/openapi.json')).rejects.toThrow('fetch failed');
+
+      global.fetch = originalFetch;
+    });
+
+    it('should extract basic auth credentials from URL into Authorization header', async () => {
+      const originalFetch = global.fetch;
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: async () => '{}'
+      } as Response);
+      global.fetch = mockFetch;
+
+      await reader.readFile('https://user:pass@example.com/openapi.json');
+
+      expect(mockFetch).toHaveBeenCalledWith('https://example.com/openapi.json', { headers: { Authorization: `Basic ${btoa('user:pass')}` } });
+
+      global.fetch = originalFetch;
+    });
+
+    it('should decode percent-encoded credentials from URL', async () => {
+      const originalFetch = global.fetch;
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: async () => '{}'
+      } as Response);
+      global.fetch = mockFetch;
+
+      await reader.readFile('https://julien%2Bstaging%40saris.ai:qwerty123@api.staging.saris.ai/api/openapi.json');
+
+      expect(mockFetch).toHaveBeenCalledWith('https://api.staging.saris.ai/api/openapi.json', { headers: { Authorization: `Basic ${btoa('julien+staging@saris.ai:qwerty123')}` } });
+
+      global.fetch = originalFetch;
+    });
+
+    it('should not treat non-http schemes as URLs', async () => {
+      await expect(reader.readFile('file:///etc/passwd')).rejects.toThrow();
     });
   });
 });


### PR DESCRIPTION
# Pull Request

## 📋 Description

Fix the CLI's handling of URL inputs (`--input` / `-i`). Previously, passing a URL (especially one with embedded credentials) would produce a misleading `ENOENT: no such file or directory` error because fetch failures were caught by a catch-all handler that fell back to `readFileSync`.

## 🔗 Related Issues

N/A

## 📝 Changes Made

- [x] Separated URL detection (`isUrl()`) from fetch logic so network errors propagate correctly instead of falling back to `readFileSync`
- [x] Added `fetchUrl()` method that extracts embedded basic auth credentials (e.g. `https://user:pass@host/path`) into an `Authorization` header, since Node's `fetch` strips them
- [x] Percent-encoded credentials (e.g. `julien%2Bstaging%40saris.ai`) are properly decoded before encoding as Basic auth
- [x] Only `http:` and `https:` schemes are treated as URLs (rejects `file://` etc.)

## 🧪 Testing

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed
- [x] New tests added (if applicable)

### New Tests

- Network error propagation (no silent fallback to `readFileSync` for valid URLs)
- Basic auth credential extraction and Authorization header generation
- Percent-encoded credential decoding (reproduces the reported `julien%2Bstaging@saris.ai` case)
- Non-HTTP scheme rejection (`file://`)
- Integration test fetching a remote Petstore spec via URL

### Test Commands

```bash
npm run test
npm run test:coverage
npm run validate
```

## 📸 Screenshots

N/A

## 🏁 Checklist

### Code Quality

- [x] Code follows the project's coding standards
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Code is properly documented
- [x] Type definitions are updated (if applicable)

### Documentation

- [ ] README updated (if applicable)
- [x] CHANGELOG updated (will be handled by semantic-release)
- [ ] JSDoc comments added for new functions

### Git & CI

- [x] Commit messages follow conventional commit format
- [x] CI pipeline passes
- [x] Branch is up to date with main
- [x] No merge conflicts

### Review

- [x] Self-review completed
- [x] Breaking changes documented
- [x] Backward compatibility maintained (or breaking changes justified)

## 🚀 Deployment Notes

No special deployment considerations. This is a bugfix with no breaking changes.

## 📚 Additional Notes

The root cause was a single `try/catch` block that wrapped both `new URL(path)` (URL detection) and `fetch()` (network request). When `fetch()` failed for a valid URL, the catch block treated it as "not a URL" and called `readFileSync(url_string)`, which produced the confusing ENOENT error.

---

**By submitting this PR, I confirm that:**

- [x] I have read and agree to the project's [Contributing Guidelines](CONTRIBUTING.md)
- [x] My code follows the project's code style and conventions
- [x] I have tested my changes thoroughly