### PR TITLE
fix(generator): correct path-template middle segment for multi-param paths

### DIFF
--- a/src/services/code-generator.service.ts
+++ b/src/services/code-generator.service.ts
@@ -1398,21 +1398,18 @@ export class TypeScriptCodeGeneratorService implements CodeGenerator, SchemaBuil
 
     // Build template expression
     const templateSpans: ts.TemplateSpan[] = [];
-    let lastIndex = 0;
 
     for (const [index, m] of matches.entries()) {
-      const before = path.substring(lastIndex, m.index);
       const sanitizedName = this.typeBuilder.sanitizeIdentifier(m.name);
-      const isLast = index === matches.length - 1;
-      const after = isLast ? path.substring(m.index + m.length) : '';
+      const next = matches[index + 1];
 
-      if (isLast) {
+      if (next === undefined) {
+        const after = path.substring(m.index + m.length);
         templateSpans.push(ts.factory.createTemplateSpan(ts.factory.createIdentifier(sanitizedName), ts.factory.createTemplateTail(after, after)));
       } else {
-        templateSpans.push(ts.factory.createTemplateSpan(ts.factory.createIdentifier(sanitizedName), ts.factory.createTemplateMiddle(before, before)));
+        const middle = path.substring(m.index + m.length, next.index);
+        templateSpans.push(ts.factory.createTemplateSpan(ts.factory.createIdentifier(sanitizedName), ts.factory.createTemplateMiddle(middle, middle)));
       }
-
-      lastIndex = m.index + m.length;
     }
 
     const firstMatch = matches[0];

--- a/tests/unit/code-generator.test.ts
+++ b/tests/unit/code-generator.test.ts
@@ -466,6 +466,40 @@ describe('TypeScriptCodeGeneratorService', () => {
       expect(code).toContain('z.array');
       expect(code).toContain('z.string()');
     });
+
+    it('should preserve literal segments between path parameters for multi-param paths', () => {
+      const spec: OpenApiSpecType = {
+        openapi: '3.0.0',
+        info: {
+          title: 'Test API',
+          version: '1.0.0'
+        },
+        paths: {
+          '/api/v2/users/{user_id}/roles/{code}': {
+            delete: {
+              operationId: 'revokeUserRole',
+              parameters: [
+                { name: 'user_id', in: 'path', required: true, schema: { type: 'string' } },
+                { name: 'code', in: 'path', required: true, schema: { type: 'string' } }
+              ],
+              responses: {
+                '204': {
+                  description: 'No Content'
+                }
+              }
+            }
+          }
+        }
+      };
+
+      const code = generator.generate(spec);
+
+      // The generated URL template must keep the literal '/roles/' between the
+      // two path parameters. Previously this segment was incorrectly replaced
+      // with the head segment, yielding `/api/v2/users/${user_id}/api/v2/users/${code}`.
+      expect(code).toContain('`/api/v2/users/${user_id}/roles/${code}`');
+      expect(code).not.toContain('/api/v2/users/${user_id}/api/v2/users/${code}');
+    });
   });
 
   describe('ResponseValidationError', () => {


### PR DESCRIPTION
## Summary

`TypeScriptCodeGeneratorService.buildPathExpression` builds a TypeScript template-literal AST from OpenAPI paths. For paths with **two or more** path parameters, the literal segment *between* consecutive parameters was incorrectly populated with the **head** segment (everything from `lastIndex` up to the current param) instead of the actual **middle** segment (from the current param's end up to the next param's start).

Single-parameter paths were unaffected because the `isLast` branch uses the correct tail substring (`path.substring(m.index + m.length)`).

## Reproduction

OpenAPI path: `/api/v2/users/{user_id}/roles/{code}`

**Before this PR (broken):**

```ts
`/api/v2/users/${user_id}/api/v2/users/${code}`
```

**After this PR (correct):**

```ts
`/api/v2/users/${user_id}/roles/${code}`
```

The bug fires on any spec with multi-parameter paths, which are extremely common in REST APIs (e.g. `/users/{user_id}/roles/{code}`, `/orgs/{org}/repos/{repo}/issues/{number}`, etc.).

## Fix

`src/services/code-generator.service.ts` — `buildPathExpression`:

- For non-last matches, compute the inter-parameter substring as `path.substring(m.index + m.length, next.index)` (current end → next start) and pass that as the template middle, instead of the previously-used `before = path.substring(lastIndex, m.index)` (head segment).
- Drop the now-unused `lastIndex` accumulator and `before` variable.

Net diff is 5 added / 8 removed.

## Regression test

Added a new case in `tests/unit/code-generator.test.ts` under `TypeScriptCodeGeneratorService > generate`:

> `should preserve literal segments between path parameters for multi-param paths`

It generates code from a spec with `/api/v2/users/{user_id}/roles/{code}` and asserts the output contains the literal `` `/api/v2/users/${user_id}/roles/${code}` `` and **not** the buggy `` /api/v2/users/${user_id}/api/v2/users/${code} ``.

## Validation

- `npm run validate` (type-check + lint + format + test): all green
- Full suite: 202/202 tests pass (was 201, +1 for the new regression test)
- Lint clean, prettier clean, type-check clean

## Notes

Happy to adjust the test placement, naming, or commit message style if you'd prefer something different.