### PR TITLE
fix(generator): skip JSON parse for 204/205 No Content responses

### DIFF
--- a/src/services/code-generator.service.ts
+++ b/src/services/code-generator.service.ts
@@ -1087,6 +1087,31 @@ export class TypeScriptCodeGeneratorService implements CodeGenerator, SchemaBuil
             ),
             undefined
           ),
+          // Skip JSON parse for 204 No Content / 205 Reset Content (RFC 7231: bodies MUST be empty)
+          ts.factory.createIfStatement(
+            ts.factory.createBinaryExpression(
+              ts.factory.createBinaryExpression(
+                ts.factory.createPropertyAccessExpression(ts.factory.createIdentifier('response'), ts.factory.createIdentifier('status')),
+                ts.factory.createToken(ts.SyntaxKind.EqualsEqualsEqualsToken),
+                ts.factory.createNumericLiteral(204)
+              ),
+              ts.factory.createToken(ts.SyntaxKind.BarBarToken),
+              ts.factory.createBinaryExpression(
+                ts.factory.createPropertyAccessExpression(ts.factory.createIdentifier('response'), ts.factory.createIdentifier('status')),
+                ts.factory.createToken(ts.SyntaxKind.EqualsEqualsEqualsToken),
+                ts.factory.createNumericLiteral(205)
+              )
+            ),
+            ts.factory.createBlock(
+              [
+                ts.factory.createReturnStatement(
+                  ts.factory.createAsExpression(ts.factory.createIdentifier('undefined'), ts.factory.createTypeReferenceNode(ts.factory.createIdentifier('T'), undefined))
+                )
+              ],
+              true
+            ),
+            undefined
+          ),
           // Return parsed JSON
           ts.factory.createReturnStatement(
             ts.factory.createAwaitExpression(

--- a/tests/unit/code-generator.test.ts
+++ b/tests/unit/code-generator.test.ts
@@ -500,6 +500,40 @@ describe('TypeScriptCodeGeneratorService', () => {
       expect(code).toContain('`/api/v2/users/${user_id}/roles/${code}`');
       expect(code).not.toContain('/api/v2/users/${user_id}/api/v2/users/${code}');
     });
+
+    it('should skip JSON parse in makeRequest for 204/205 No Content responses', () => {
+      const spec: OpenApiSpecType = {
+        openapi: '3.0.0',
+        info: {
+          title: 'Test API',
+          version: '1.0.0'
+        },
+        paths: {
+          '/items/{id}': {
+            delete: {
+              operationId: 'deleteItem',
+              parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+              responses: {
+                '204': {
+                  description: 'No Content'
+                }
+              }
+            }
+          }
+        }
+      };
+
+      const code = generator.generate(spec);
+
+      // The generated makeRequest implementation must guard against parsing
+      // empty bodies for 204/205 responses. Without this guard, `response.json()`
+      // throws "Unexpected end of JSON input" for any endpoint that returns
+      // 204 No Content (commonly DELETE endpoints declared `Promise<void>`).
+      // Per RFC 7231 §6.3.5 / §6.3.6, 204 and 205 MUST have empty bodies.
+      expect(code).toContain('response.status === 204');
+      expect(code).toContain('response.status === 205');
+      expect(code).toContain('return undefined as T');
+    });
   });
 
   describe('ResponseValidationError', () => {


### PR DESCRIPTION
## Summary

The generated `makeRequest` method calls `await response.json()` unconditionally, which throws `Failed to execute 'json' on 'Response': Unexpected end of JSON input` for endpoints returning `204 No Content` or `205 Reset Content` (per RFC 7231, these MUST have empty bodies).

The generator already correctly emits `Promise<void>` return types for OpenAPI endpoints declared with `204` responses (no `responses.200.content` schema), so the runtime behavior should match — skip the parse for those status codes and return `undefined`.

## Repro

Any OpenAPI spec with a `DELETE` endpoint declared as `responses: { "204": { description: "..." } }` (no content) generates a `Promise<void>` method that, when called, throws on the JSON parse.

## Fix

Guard the `response.json()` call with a status check before parsing. Adds the equivalent of:

```ts
if (response.status === 204 || response.status === 205) {
    return undefined as T;
}
return await response.json();
```

## Tests

Added a regression test under `tests/unit/code-generator.test.ts` asserting the 204 guard is present in the generated `makeRequest` source (mirror the style used by the multi-param path-template test from #115).

## Context

Follow-up to #115 — same generator, separate bug. The downstream SDK (`@saris-ai/api`) ships a couple dozen DELETE endpoints in its new RBAC slice and we're hitting this on every revoke/delete operation.